### PR TITLE
Fix! Entities are removed when the node goes down

### DIFF
--- a/apps/massa_proxy/lib/massa_proxy/cluster/entity/entity_registry_supervisor.ex
+++ b/apps/massa_proxy/lib/massa_proxy/cluster/entity/entity_registry_supervisor.ex
@@ -7,7 +7,7 @@ defmodule MassaProxy.Entity.EntityRegistry.Supervisor do
   end
 
   @impl true
-  def init(args) do
+  def init(_args) do
     children = [
       {Phoenix.PubSub, name: :entity_channel},
       MassaProxy.Entity.EntityRegistry.child_spec(%{})


### PR DESCRIPTION
Handles non-graceful exists by monitoring the nodes and removing the entities for that node if that happens. Closes #39

There's two scenarios which are covered here:

1. A graceful shutdown of the process will call the terminate callback publishing a leave. I don't know how applicable this scenario is or that the process should just respond to `:nodedown`.
2. Handles node shutdown, graceful or not

## Testing

* Start two nodes:
```bash
NODE_COOKIE=secret PROXY_PORT=5000 PROXY_HTTP_PORT=5001 iex --name massa-001@127.0.0.1 -S mix
USER_FUNCTION_PORT=4000 NODE_COOKIE=secret iex --name massa-002@127.0.0.1 --cookie secret -S mix
```

* Shutdown with `ctrl+c a` or  calling `System.stop`
```elixir
iex> System.stop()
```
* Check on node2 that it contains no entities:

```elixir
iex> GenServer.call(MassaProxy.Entity.EntityRegistry, {:get, "cloudstate.action.ActionProtocol"})
```