### PR TITLE
Send entity information on join to node joining. Closes #91

### DIFF
--- a/apps/massa_proxy/lib/massa_proxy/cluster/entity/entity_registry.ex
+++ b/apps/massa_proxy/lib/massa_proxy/cluster/entity/entity_registry.ex
@@ -23,7 +23,18 @@ defmodule MassaProxy.Entity.EntityRegistry do
 
     Logger.debug("Initializing Entity Registry with state #{inspect(state)}")
 
-    {:ok, state}
+    {:ok, state, {:continue, :join_cluster}}
+  end
+
+  @impl true
+  def handle_continue(:join_cluster, state) do
+    PubSub.broadcast(
+      :entity_channel,
+      @topic,
+      {:join, %{node: node()}}
+    )
+
+    {:noreply, state}
   end
 
   @impl true
@@ -49,7 +60,7 @@ defmodule MassaProxy.Entity.EntityRegistry do
     PubSub.broadcast(
       :entity_channel,
       @topic,
-      {:join, %{node => new_entities}}
+      {:new_entities, %{node => new_entities}}
     )
 
     {:noreply, new_state}
@@ -77,7 +88,7 @@ defmodule MassaProxy.Entity.EntityRegistry do
   end
 
   @impl true
-  def handle_info({:join, message}, state) do
+  def handle_info({:new_entities, message}, state) do
     self = Node.self()
 
     if Map.has_key?(message, self) do
@@ -89,8 +100,18 @@ defmodule MassaProxy.Entity.EntityRegistry do
     end
   end
 
+
+  def handle_info({:join, %{node: node}}, state) do
+    Logger.debug(fn -> "Got Node join from #{inspect(node)} sending current state" end)
+
+    :ok = PubSub.direct_broadcast(node, :entity_channel, @topic, {:new_entities, Map.take(state, [node()])})
+
+    {:noreply, state}
+  end
+
   def handle_info({:nodeup, _node, _node_type}, state) do
-    # Ignore the nodeup as the `:join` message will be broadcasted through PubSub
+    # Ignore :nodeup as we are expecting a :join message before sending a reply
+    # with the current state
     {:noreply, state}
   end
 


### PR DESCRIPTION
Introduces a slight change to the protocol between entity registries. Instead of relying on discovery to kick in to send information all nodes, this change allows for nodes to send *their* current state to the joining node when it receives a join message. So the issues observed in #91 where a joining node does not receive any entity information up to 60 seconds after it successfully joined the cluster is fixed. 

This will allow for instance to send deltas of changes picked up in discovery, as the full state would have been transmitted on join.